### PR TITLE
Request and BodyRequest can be initialised with extra headers as required.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,22 @@ client.request(request, success: User.self, error: RegistrationError.self) { res
     }
 }
 ```
+
+GET request with HTTP headers.
+
+```swift
+let client = Client()
+let headers = ["Cookie": "tasty_cookie=strawberry"]
+let request = Request(url: url, headers: headers)
+client.request(request, success: Empty.self, error: Empty.self) { _ in }
+```
+
+You can also use an URLRequest object with the Client if you require more fine grained control.
+
+```swift
+let client = Client()
+let request = URLRequest(url: url,
+                         cachePolicy: .reloadIgnoringLocalCacheData,
+                         timeoutInterval: 42.0)
+client.request(request, success: Empty.self, error: Empty.self) { _ in }
+```

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ client.request(request, success: User.self, error: RegistrationError.self) { res
 }
 ```
 
-GET request with HTTP headers.
+HTTP headers can also be set on `Request`.
 
 ```swift
 let client = Client()
@@ -72,12 +72,14 @@ let request = Request(url: url, headers: headers)
 client.request(request, success: Empty.self, error: Empty.self) { _ in }
 ```
 
-You can also use an URLRequest object with the Client if you require more fine grained control.
+`URLRequest` can be used directly if you require more fine grained control.
 
 ```swift
 let client = Client()
-let request = URLRequest(url: url,
-                         cachePolicy: .reloadIgnoringLocalCacheData,
-                         timeoutInterval: 42.0)
+let request = URLRequest(
+    url: url,
+    cachePolicy: .reloadIgnoringLocalCacheData,
+    timeoutInterval: 42.0
+)
 client.request(request, success: Empty.self, error: Empty.self) { _ in }
 ```

--- a/Sources/HTTP/BodyRequest.swift
+++ b/Sources/HTTP/BodyRequest.swift
@@ -1,8 +1,7 @@
 import Foundation
 
 public class BodyRequest<T: Encodable>: Request {
-    public init(url: URL, method: Method = .get, body: T,
-                headers: HTTPHeaderFields = [:]) {
+    public init(url: URL, method: Method = .get, body: T, headers: Headers = [:]) {
         self.body = body
         super.init(url: url, method: method, headers: headers)
     }

--- a/Sources/HTTP/BodyRequest.swift
+++ b/Sources/HTTP/BodyRequest.swift
@@ -1,9 +1,10 @@
 import Foundation
 
 public class BodyRequest<T: Encodable>: Request {
-    public init(url: URL, method: Method = .get, body: T) {
+    public init(url: URL, method: Method = .get, body: T,
+                headers: HTTPHeaderFields = [:]) {
         self.body = body
-        super.init(url: url, method: method)
+        super.init(url: url, method: method, headers: headers)
     }
 
     // MARK: Internal

--- a/Sources/HTTP/Client.swift
+++ b/Sources/HTTP/Client.swift
@@ -13,8 +13,8 @@ public struct Client {
         self.request(request.asURLRequest, success: success, error: error, completion: completion)
     }
 
-    public func request<T, E>(_ urlRequest: URLRequest, success: T.Type, error: E.Type, completion: @escaping Completion<T, E>) {
-        requestLoader.load(urlRequest) { data, response, error in
+    public func request<T, E>(_ request: URLRequest, success: T.Type, error: E.Type, completion: @escaping Completion<T, E>) {
+        requestLoader.load(request) { data, response, error in
             if let error = error {
                 completion(.failure(.failedRequest(error)))
             } else if let response = response as? HTTPURLResponse {

--- a/Sources/HTTP/Client.swift
+++ b/Sources/HTTP/Client.swift
@@ -10,7 +10,11 @@ public struct Client {
     }
 
     public func request<T, E>(_ request: Request, success: T.Type, error: E.Type, completion: @escaping Completion<T, E>) {
-        requestLoader.load(request.asURLRequest) { data, response, error in
+        self.request(request.asURLRequest, success: success, error: error, completion: completion)
+    }
+
+    public func request<T, E>(_ urlRequest: URLRequest, success: T.Type, error: E.Type, completion: @escaping Completion<T, E>) {
+        requestLoader.load(urlRequest) { data, response, error in
             if let error = error {
                 completion(.failure(.failedRequest(error)))
             } else if let response = response as? HTTPURLResponse {

--- a/Sources/HTTP/Request.swift
+++ b/Sources/HTTP/Request.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 public class Request {
-    public typealias HTTPHeaderFields = [String : String]
-    
-    public init(url: URL, method: Method = .get, headers: HTTPHeaderFields = [:]) {
+    public typealias Headers = [String: String]
+
+    public init(url: URL, method: Method = .get, headers: Headers = [:]) {
         self.url = url
         self.method = method
         self.headers = headers
@@ -23,7 +23,7 @@ public class Request {
 
     // MARK: Private
 
+    private let headers: Headers
     private let method: Method
     private let url: URL
-    private let headers: HTTPHeaderFields
 }

--- a/Sources/HTTP/Request.swift
+++ b/Sources/HTTP/Request.swift
@@ -1,9 +1,12 @@
 import Foundation
 
 public class Request {
-    public init(url: URL, method: Method = .get) {
+    public typealias HTTPHeaderFields = [String : String]
+    
+    public init(url: URL, method: Method = .get, headers: HTTPHeaderFields = [:]) {
         self.url = url
         self.method = method
+        self.headers = headers
     }
 
     // MARK: Internal
@@ -11,6 +14,7 @@ public class Request {
     var asURLRequest: URLRequest {
         var request = URLRequest(url: url)
         request.httpMethod = method.rawValue
+        request.allHTTPHeaderFields = headers
         addToRequest(&request)
         return request
     }
@@ -21,4 +25,5 @@ public class Request {
 
     private let method: Method
     private let url: URL
+    private let headers: HTTPHeaderFields
 }

--- a/Tests/HTTPTests/BodyRequestTests.swift
+++ b/Tests/HTTPTests/BodyRequestTests.swift
@@ -18,4 +18,21 @@ class BodyRequestTests: XCTestCase {
         let urlRequest = request.asURLRequest
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
     }
+    
+    func test_init_setsTheAllHTTPHeaderFields() {
+        let expectedCookies = "yummy_cookie=choco; tasty_cookie=strawberry"
+        let request = BodyRequest(url: URL.test, body: TestObject(),
+                                  headers: ["Cookie": expectedCookies])
+        let urlRequest = request.asURLRequest
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Cookie"), expectedCookies)
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+    
+    func test_init_always_overrides_setsJSONAsTheContentTypeHeader() {
+        let request = BodyRequest(url: URL.test, body: TestObject(),
+                                  headers: ["Content-Type": "text/html"])
+        let urlRequest = request.asURLRequest
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
+
 }

--- a/Tests/HTTPTests/BodyRequestTests.swift
+++ b/Tests/HTTPTests/BodyRequestTests.swift
@@ -18,21 +18,16 @@ class BodyRequestTests: XCTestCase {
         let urlRequest = request.asURLRequest
         XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
     }
-    
-    func test_init_setsTheAllHTTPHeaderFields() {
-        let expectedCookies = "yummy_cookie=choco; tasty_cookie=strawberry"
-        let request = BodyRequest(url: URL.test, body: TestObject(),
-                                  headers: ["Cookie": expectedCookies])
-        let urlRequest = request.asURLRequest
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Cookie"), expectedCookies)
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
-    }
-    
-    func test_init_always_overrides_setsJSONAsTheContentTypeHeader() {
-        let request = BodyRequest(url: URL.test, body: TestObject(),
-                                  headers: ["Content-Type": "text/html"])
-        let urlRequest = request.asURLRequest
-        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
-    }
 
+    func test_init_setsTheAllHTTPHeaderFields() {
+        let request = BodyRequest(
+            url: URL.test,
+            body: TestObject(),
+            headers: ["Cookie": "yummy_cookie=choco;"]
+        )
+
+        let urlRequest = request.asURLRequest
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Cookie"), "yummy_cookie=choco;")
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "Content-Type"), "application/json")
+    }
 }

--- a/Tests/HTTPTests/ClientTests.swift
+++ b/Tests/HTTPTests/ClientTests.swift
@@ -13,6 +13,16 @@ final class ClientTests: XCTestCase {
         XCTAssertEqual(requestLoader.lastLoadedRequest, URLRequest.test)
     }
 
+    func test_request_withURLRequest_loadsTheRequest() {
+        let requestLoader = FakeRequestLoader()
+        let client = Client(requestLoader: requestLoader)
+
+        let expectedURLRequest = URLRequest.testWithExtraProperties
+        client.request(expectedURLRequest, success: Empty.self, error: Empty.self) { _ in }
+
+        XCTAssertEqual(requestLoader.lastLoadedRequest, expectedURLRequest)
+    }
+    
     func test_request_failsWithANetworkError() {
         let requestLoader = FakeRequestLoader()
         let client = Client(requestLoader: requestLoader)

--- a/Tests/HTTPTests/ClientTests.swift
+++ b/Tests/HTTPTests/ClientTests.swift
@@ -22,7 +22,7 @@ final class ClientTests: XCTestCase {
 
         XCTAssertEqual(requestLoader.lastLoadedRequest, expectedURLRequest)
     }
-    
+
     func test_request_failsWithANetworkError() {
         let requestLoader = FakeRequestLoader()
         let client = Client(requestLoader: requestLoader)

--- a/Tests/HTTPTests/RequestTests.swift
+++ b/Tests/HTTPTests/RequestTests.swift
@@ -16,13 +16,10 @@ class RequestTests: XCTestCase {
         let postRequest = Request(url: URL.test, method: .post)
         XCTAssertEqual(postRequest.asURLRequest.httpMethod, "POST")
     }
-    
-    func test_asURLRequest_setsTheAllHTTPHeaderFields() {
-        let noHeadersRequest = Request(url: URL.test)
-        XCTAssertTrue(noHeadersRequest.asURLRequest.allHTTPHeaderFields?.isEmpty ?? false)
-        
-        let expectedHeaders = ["Cookie":"yummy_cookie=choco; tasty_cookie=strawberry"]
-        let headersRequest = Request(url: URL.test, headers: expectedHeaders)
-        XCTAssertEqual(headersRequest.asURLRequest.allHTTPHeaderFields ?? [:], expectedHeaders)
+
+    func test_asURLRequest_setsAllHTTPHeaderFields() {
+        let headers = ["Cookie": "yummy_cookie=choco; tasty_cookie=strawberry;"]
+        let requestWithHeaders = Request(url: URL.test, headers: headers)
+        XCTAssertEqual(requestWithHeaders.asURLRequest.allHTTPHeaderFields, headers)
     }
 }

--- a/Tests/HTTPTests/RequestTests.swift
+++ b/Tests/HTTPTests/RequestTests.swift
@@ -16,4 +16,13 @@ class RequestTests: XCTestCase {
         let postRequest = Request(url: URL.test, method: .post)
         XCTAssertEqual(postRequest.asURLRequest.httpMethod, "POST")
     }
+    
+    func test_asURLRequest_setsTheAllHTTPHeaderFields() {
+        let noHeadersRequest = Request(url: URL.test)
+        XCTAssertTrue(noHeadersRequest.asURLRequest.allHTTPHeaderFields?.isEmpty ?? false)
+        
+        let expectedHeaders = ["Cookie":"yummy_cookie=choco; tasty_cookie=strawberry"]
+        let headersRequest = Request(url: URL.test, headers: expectedHeaders)
+        XCTAssertEqual(headersRequest.asURLRequest.allHTTPHeaderFields ?? [:], expectedHeaders)
+    }
 }

--- a/Tests/HTTPTests/Support/Helpers/READMEHelper.swift
+++ b/Tests/HTTPTests/Support/Helpers/READMEHelper.swift
@@ -14,6 +14,21 @@ struct GETRequest {
             }
         }
     }
+    
+    func exampleWithHeaders() {
+        let client = Client()
+        let headers = ["Cookie": "tasty_cookie=strawberry"]
+        let request = Request(url: url, headers: headers)
+        client.request(request, success: Empty.self, error: Empty.self) { _ in }
+    }
+    
+    func exampleWithURLRequest() {
+        let client = Client()
+        let request = URLRequest(url: url,
+                                 cachePolicy: .reloadIgnoringLocalCacheData,
+                                 timeoutInterval: 42.0)
+        client.request(request, success: Empty.self, error: Empty.self) { _ in }
+    }
 }
 
 struct POSTRequest {

--- a/Tests/HTTPTests/Support/Helpers/READMEHelper.swift
+++ b/Tests/HTTPTests/Support/Helpers/READMEHelper.swift
@@ -3,7 +3,7 @@ import HTTP
 
 let url = URL.test
 
-struct GETRequest {
+struct GETRequestExample {
     func example() {
         let client = Client()
         let request = Request(url: url)
@@ -14,24 +14,9 @@ struct GETRequest {
             }
         }
     }
-    
-    func exampleWithHeaders() {
-        let client = Client()
-        let headers = ["Cookie": "tasty_cookie=strawberry"]
-        let request = Request(url: url, headers: headers)
-        client.request(request, success: Empty.self, error: Empty.self) { _ in }
-    }
-    
-    func exampleWithURLRequest() {
-        let client = Client()
-        let request = URLRequest(url: url,
-                                 cachePolicy: .reloadIgnoringLocalCacheData,
-                                 timeoutInterval: 42.0)
-        client.request(request, success: Empty.self, error: Empty.self) { _ in }
-    }
 }
 
-struct POSTRequest {
+struct POSTRequestExample {
     func example() {
         struct Registration: Codable {
             let email: String
@@ -62,5 +47,26 @@ struct POSTRequest {
                 print("Error", error.localizedDescription)
             }
         }
+    }
+}
+
+struct RequestWithHeadersExample {
+    func example() {
+        let client = Client()
+        let headers = ["Cookie": "tasty_cookie=strawberry"]
+        let request = Request(url: url, headers: headers)
+        client.request(request, success: Empty.self, error: Empty.self) { _ in }
+    }
+}
+
+struct URLRequestExample {
+    func example() {
+        let client = Client()
+        let request = URLRequest(
+            url: url,
+            cachePolicy: .reloadIgnoringLocalCacheData,
+            timeoutInterval: 42.0
+        )
+        client.request(request, success: Empty.self, error: Empty.self) { _ in }
     }
 }

--- a/Tests/HTTPTests/Support/Helpers/URLHelper.swift
+++ b/Tests/HTTPTests/Support/Helpers/URLHelper.swift
@@ -6,4 +6,7 @@ extension URL {
 
 extension URLRequest {
     static var test = Self(url: URL.test)
+    static var testWithExtraProperties = Self(url: URL.test,
+                                              cachePolicy: .reloadIgnoringLocalAndRemoteCacheData,
+                                              timeoutInterval: 42.0)
 }


### PR DESCRIPTION
I have added support to pass in headers to Request and BodyRequest which in turn will be set on the underlying URLRequest object.
**NOTE:** BodyRequest will still override any headers it requires like the Content-Type.

Additionally I have also made the Client be able to make a request directly using a URLRequest object. This is to cover scenarios where the caller needs more properties exposed by URLRequest but still want to leverage all the goodies provided by this Swift package.

**Testing**
I used TDD to make my changes.
Run all unit tests against the Mac and iPhone targets and all tests passed.