### PR TITLE
JSON key encoding/decoding strategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2022
 
+* July 20 - Set default key coding strategy to snake case - [#3](https://github.com/joemasilotti/HTTP-Client/pull/3)
 * July 20 - Convert project to async-await - [#2](https://github.com/joemasilotti/HTTP-Client/pull/2)
 
 ## 2021

--- a/README.md
+++ b/README.md
@@ -84,3 +84,16 @@ let request = URLRequest(
 )
 _ = await client.request(request)
 ```
+
+## Key encoding strategies
+
+By default, all encoding and decoding of keys to JSON is done by converting to snake case.
+
+This can be changed via the global configuration.
+
+```swift
+import HTTP
+
+HTTP.Global.keyDecodingStrategy = .useDefaultKeys
+HTTP.Global.keyEncodingStrategy = .useDefaultKeys
+```

--- a/Sources/HTTP/BodyRequest.swift
+++ b/Sources/HTTP/BodyRequest.swift
@@ -1,11 +1,8 @@
 import Foundation
 
 public class BodyRequest<T: Encodable>: Request {
-    private let keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy
-
-    public init(url: URL, method: Method = .get, body: T, headers: Headers = [:], keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .useDefaultKeys) {
+    public init(url: URL, method: Method = .get, body: T, headers: Headers = [:]) {
         self.body = body
-        self.keyEncodingStrategy = keyEncodingStrategy
         super.init(url: url, method: method, headers: headers)
     }
 
@@ -13,7 +10,7 @@ public class BodyRequest<T: Encodable>: Request {
 
     override func addToRequest(_ request: inout URLRequest) {
         let encoder = JSONEncoder()
-        encoder.keyEncodingStrategy = keyEncodingStrategy
+        encoder.keyEncodingStrategy = Global.keyEncodingStrategy
         request.httpBody = try? encoder.encode(body)
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
     }

--- a/Sources/HTTP/Global.swift
+++ b/Sources/HTTP/Global.swift
@@ -1,9 +1,13 @@
 import Foundation
 
 public enum Global {
+    public static var keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = .convertFromSnakeCase
+    public static var keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .convertToSnakeCase
     public static var requestLoader: RequestLoader = URLSession.shared
 
     static func resetToDefaults() {
+        keyDecodingStrategy = .convertFromSnakeCase
+        keyEncodingStrategy = .convertToSnakeCase
         requestLoader = URLSession.shared
     }
 }

--- a/Tests/HTTPTests/ClientTests.swift
+++ b/Tests/HTTPTests/ClientTests.swift
@@ -39,7 +39,7 @@ final class ClientTests: XCTestCase {
         let client = Client<TestObject, Empty>(requestLoader: requestLoader)
 
         let exampleObject = TestObject()
-        let data = try XCTUnwrap(JSONEncoder().encode(exampleObject))
+        let data = try XCTUnwrap(JSONEncoder.convertingKeysFromSnakeCase.encode(exampleObject))
         requestLoader.nextData = data
 
         let response = HTTPURLResponse(url: URL.test, statusCode: 200, httpVersion: nil, headerFields: ["HEADER": "value"])
@@ -95,5 +95,19 @@ final class ClientTests: XCTestCase {
 
         let result = await client.request(Request(url: URL.test))
         assertResultError(result, .failedRequest(nil))
+    }
+
+    func test_request_nonSnakeCaseKeyCodingStrategy() async throws {
+        let requestLoader = FakeRequestLoader()
+        HTTP.Global.keyEncodingStrategy = .useDefaultKeys
+        HTTP.Global.keyDecodingStrategy = .useDefaultKeys
+        let client = Client<TestObject, Empty>(requestLoader: requestLoader)
+
+        let exampleObject = TestObject()
+        let data = try XCTUnwrap(JSONEncoder().encode(exampleObject))
+        requestLoader.nextData = data
+
+        let result = await client.request(Request(url: URL.test))
+        XCTAssertEqual(try? result.get().value, exampleObject)
     }
 }

--- a/Tests/HTTPTests/Support/Extensions/Foundation/JSONDecoder.swift
+++ b/Tests/HTTPTests/Support/Extensions/Foundation/JSONDecoder.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension JSONDecoder {
+    static var convertingKeysFromSnakeCase: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        return decoder
+    }
+}

--- a/Tests/HTTPTests/Support/Extensions/Foundation/JSONEncoder.swift
+++ b/Tests/HTTPTests/Support/Extensions/Foundation/JSONEncoder.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+extension JSONEncoder {
+    static var convertingKeysFromSnakeCase: JSONEncoder {
+        let decoder = JSONEncoder()
+        decoder.keyEncodingStrategy = .convertToSnakeCase
+        return decoder
+    }
+}

--- a/Tests/HTTPTests/Support/Fixtures.swift
+++ b/Tests/HTTPTests/Support/Fixtures.swift
@@ -1,10 +1,12 @@
 import Foundation
 
 struct TestObject: Codable, Equatable {
-    let title: String
+    let property: String
+    let secondProperty: String
 
-    init(title: String = "Test Title") {
-        self.title = title
+    init(property: String = "First property", secondProperty: String = "Second property") {
+        self.property = property
+        self.secondProperty = secondProperty
     }
 }
 


### PR DESCRIPTION
By default, encode/decode by converting to snake case.