### PR TITLE
Status code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 2024
+
+* February 13 - Expose status code when possible - [#4](https://github.com/joemasilotti/HTTP-Client/pull/4)
+
 ## 2022
 
 * November 18 - Fix exception when running on iOS 14.4

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add HTTP Client as a dependency through Xcode or directly to Package.swift:
 
 ## Usage
 
-GET request with no expected success or error response object types.
+### GET request with empty responses
 
 ```swift
 import HTTP
@@ -25,7 +25,9 @@ case .failure(let error): print(error.localizedDescription)
 }
 ```
 
-POST request with HTTP body and expected success and failure response objects. Failure response objects are parsed with response codes outside the 200 range.
+### POST request with success and response objects
+
+Failure response objects are parsed when the response code is outside of the 200 range.
 
 ```swift
 import HTTP
@@ -60,6 +62,25 @@ case .failure(let error):
 }
 ```
 
+### Status code
+
+When possible, a status code is also exposed.
+
+```swift
+import HTTP
+
+let client = Client<Empty, Empty>()
+let request = Request(url: url)
+switch await client.request(request) {
+case .success(let statusCode):
+    print("Status code", statusCode)
+case .failure(let error):
+    print("Status code", error.statusCode ?? "(none)")
+}
+```
+
+### HTTP headers
+
 HTTP headers can also be set on `Request`.
 
 ```swift
@@ -70,6 +91,8 @@ let headers = ["Cookie": "tasty_cookie=strawberry"]
 let request = Request(url: url, headers: headers)
 _ = await client.request(request)
 ```
+
+### Custom `URLRequest`
 
 `URLRequest` can be used directly if you require more fine grained control.
 
@@ -85,7 +108,7 @@ let request = URLRequest(
 _ = await client.request(request)
 ```
 
-## Key encoding strategies
+### Key encoding strategies
 
 By default, all encoding and decoding of keys to JSON is done by converting to snake case.
 

--- a/Sources/HTTP/Client.swift
+++ b/Sources/HTTP/Client.swift
@@ -27,7 +27,7 @@ public struct Client<T, E> where T: Decodable, E: LocalizedError & Decodable & E
 
     private let requestLoader: RequestLoader
 
-    private func handleResponse<T>(_ response: URLResponse, with data: Data) -> ClientResult<T, E> {
+    private func handleResponse(_ response: URLResponse, with data: Data) -> ClientResult<T, E> {
         guard let response = response as? HTTPURLResponse
         else { return .failure(.failedRequest(nil)) }
 
@@ -38,7 +38,7 @@ public struct Client<T, E> where T: Decodable, E: LocalizedError & Decodable & E
         }
     }
 
-    private func handleSuccess<T, E>(_ data: Data, headers: [AnyHashable: Any]) -> ClientResult<T, E> {
+    private func handleSuccess(_ data: Data, headers: [AnyHashable: Any]) -> ClientResult<T, E> {
         if let value: T = parse(data) {
             return .success(Response(headers: headers, value: value))
         } else {
@@ -46,7 +46,7 @@ public struct Client<T, E> where T: Decodable, E: LocalizedError & Decodable & E
         }
     }
 
-    private func handleFailure<T, E>(_ data: Data, statusCode: Int) -> ClientResult<T, E> {
+    private func handleFailure(_ data: Data, statusCode: Int) -> ClientResult<T, E> {
         if let error: E = parse(data) {
             return .failure(.invalidRequest(error, statusCode))
         } else {
@@ -54,10 +54,10 @@ public struct Client<T, E> where T: Decodable, E: LocalizedError & Decodable & E
         }
     }
 
-    private func parse<T: Decodable>(_ data: Data?) -> T? {
+    private func parse<D: Decodable>(_ data: Data?) -> D? {
         guard let data = data else { return nil }
         let decoder = JSONDecoder()
         decoder.keyDecodingStrategy = Global.keyDecodingStrategy
-        return try? decoder.decode(T.self, from: data)
+        return try? decoder.decode(D.self, from: data)
     }
 }

--- a/Sources/HTTP/Client.swift
+++ b/Sources/HTTP/Client.swift
@@ -32,17 +32,17 @@ public struct Client<T, E> where T: Decodable, E: LocalizedError & Decodable & E
         else { return .failure(.failedRequest(nil)) }
 
         if (200 ..< 300).contains(response.statusCode) {
-            return handleSuccess(data, headers: response.allHeaderFields)
+            return handleSuccess(data, headers: response.allHeaderFields, statusCode: response.statusCode)
         } else {
             return handleFailure(data, statusCode: response.statusCode)
         }
     }
 
-    private func handleSuccess(_ data: Data, headers: [AnyHashable: Any]) -> ClientResult<T, E> {
+    private func handleSuccess(_ data: Data, headers: [AnyHashable: Any], statusCode: Int) -> ClientResult<T, E> {
         if let value: T = parse(data) {
-            return .success(Response(headers: headers, value: value))
+            return .success(Response(headers: headers, value: value, statusCode: statusCode))
         } else {
-            return .failure(.responseTypeMismatch)
+            return .failure(.responseTypeMismatch(statusCode))
         }
     }
 

--- a/Sources/HTTP/Client.swift
+++ b/Sources/HTTP/Client.swift
@@ -48,7 +48,7 @@ public struct Client<T, E> where T: Decodable, E: LocalizedError & Decodable & E
 
     private func handleFailure<T, E>(_ data: Data, statusCode: Int) -> ClientResult<T, E> {
         if let error: E = parse(data) {
-            return .failure(.invalidRequest(error))
+            return .failure(.invalidRequest(error, statusCode))
         } else {
             return .failure(.invalidResponse(statusCode))
         }

--- a/Sources/HTTP/HTTPError.swift
+++ b/Sources/HTTP/HTTPError.swift
@@ -4,7 +4,7 @@ public enum HTTPError<T: LocalizedError>: LocalizedError {
     case failedRequest(URLError?)
     case invalidRequest(T, Int)
     case invalidResponse(Int)
-    case responseTypeMismatch
+    case responseTypeMismatch(Int)
 
     public var errorDescription: String? {
         switch self {
@@ -30,6 +30,17 @@ public enum HTTPError<T: LocalizedError>: LocalizedError {
             case .responseTypeMismatch:
                 return "The response did not match the expected error type."
         }
+    }
+
+    public var statusCode: Int? {
+        if case let .invalidRequest(_, statusCode) = self {
+            return statusCode
+        } else if case let .invalidResponse(statusCode) = self {
+            return statusCode
+        } else if case let .responseTypeMismatch(statusCode) = self {
+            return statusCode
+        }
+        return nil
     }
 }
 

--- a/Sources/HTTP/HTTPError.swift
+++ b/Sources/HTTP/HTTPError.swift
@@ -2,7 +2,7 @@ import Foundation
 
 public enum HTTPError<T: LocalizedError>: LocalizedError {
     case failedRequest(URLError?)
-    case invalidRequest(T)
+    case invalidRequest(T, Int)
     case invalidResponse(Int)
     case responseTypeMismatch
 
@@ -10,7 +10,7 @@ public enum HTTPError<T: LocalizedError>: LocalizedError {
         switch self {
             case .failedRequest:
                 return "The request failed."
-            case let .invalidRequest(error):
+            case let .invalidRequest(error, _):
                 return error.localizedDescription
             case let .invalidResponse(statusCode):
                 return "The response was invalid (\(statusCode))."
@@ -23,7 +23,7 @@ public enum HTTPError<T: LocalizedError>: LocalizedError {
         switch self {
             case let .failedRequest(error):
                 return error?.localizedDescription
-            case let .invalidRequest(error):
+            case let .invalidRequest(error, _):
                 return error.localizedDescription
             case let .invalidResponse(statusCode):
                 return "The server returned a \(statusCode) status code."

--- a/Sources/HTTP/Response.swift
+++ b/Sources/HTTP/Response.swift
@@ -3,4 +3,5 @@ import Foundation
 public struct Response<T> {
     public let headers: [AnyHashable: Any]
     public let value: T
+    public let statusCode: Int
 }

--- a/Tests/HTTPTests/ClientTests.swift
+++ b/Tests/HTTPTests/ClientTests.swift
@@ -48,6 +48,7 @@ final class ClientTests: XCTestCase {
         let result = await client.request(Request(url: URL.test))
         XCTAssertEqual(try? result.get().value, exampleObject)
         XCTAssertEqual(try? result.get().headers as? [String: String], ["HEADER": "value"])
+        XCTAssertEqual(try? result.get().statusCode, 200)
     }
 
     func test_request_200range_failsWhenParsingFails() async {
@@ -58,7 +59,7 @@ final class ClientTests: XCTestCase {
         requestLoader.nextResponse = response
 
         let result = await client.request(Request(url: URL.test))
-        assertResultError(result, .responseTypeMismatch)
+        assertResultError(result, .responseTypeMismatch(200))
     }
 
     func test_request_non200range_failsWithParsedErrorObject() async throws {

--- a/Tests/HTTPTests/ClientTests.swift
+++ b/Tests/HTTPTests/ClientTests.swift
@@ -73,7 +73,7 @@ final class ClientTests: XCTestCase {
         requestLoader.nextResponse = response
 
         let result = await client.request(Request(url: URL.test))
-        assertResultError(result, .invalidRequest(error))
+        assertResultError(result, .invalidRequest(error, 403))
     }
 
     func test_request_non200range_failsWhenParsingFails() async {

--- a/Tests/HTTPTests/Support/Helpers/READMEHelper.swift
+++ b/Tests/HTTPTests/Support/Helpers/READMEHelper.swift
@@ -46,6 +46,19 @@ struct POSTRequestExample {
     }
 }
 
+struct StatusCodeExmaple {
+    func example() async {
+        let client = Client<Empty, Empty>()
+        let request = Request(url: url)
+        switch await client.request(request) {
+        case .success(let statusCode):
+            print("Status code", statusCode)
+        case .failure(let error):
+            print("Status code", error.statusCode ?? "(none)")
+        }
+    }
+}
+
 struct RequestWithHeadersExample {
     func example() async {
         let client = Client<Empty, Empty>()


### PR DESCRIPTION
This PR adds an additional associated value to the `.invalidRequest` error, the HTTP status code. This additional context is useful to determine if there is an extra step involved in a request, like requesting a MFA code during authentication.