### PR TITLE
User agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## 2024
 
+* February 13 - Option to set a user agent for all request - [#5](https://github.com/joemasilotti/HTTP-Client/pull/5)
 * February 13 - Expose status code when possible - [#4](https://github.com/joemasilotti/HTTP-Client/pull/4)
 
 ## 2022

--- a/README.md
+++ b/README.md
@@ -108,6 +108,16 @@ let request = URLRequest(
 _ = await client.request(request)
 ```
 
+### User agent
+
+A user agent can also be set for all requests, assigning the `"User-Agent"` header.
+
+```swift
+import HTTP
+
+HTTP.Global.userAgent = "Custom User Agent"
+```
+
 ### Key encoding strategies
 
 By default, all encoding and decoding of keys to JSON is done by converting to snake case.

--- a/Sources/HTTP/Global.swift
+++ b/Sources/HTTP/Global.swift
@@ -3,11 +3,13 @@ import Foundation
 public enum Global {
     public static var keyDecodingStrategy: JSONDecoder.KeyDecodingStrategy = .convertFromSnakeCase
     public static var keyEncodingStrategy: JSONEncoder.KeyEncodingStrategy = .convertToSnakeCase
+    public static var userAgent: String?
     public static var requestLoader: RequestLoader = URLSession.shared
 
     static func resetToDefaults() {
         keyDecodingStrategy = .convertFromSnakeCase
         keyEncodingStrategy = .convertToSnakeCase
+        userAgent = nil
         requestLoader = URLSession.shared
     }
 }

--- a/Sources/HTTP/Request.swift
+++ b/Sources/HTTP/Request.swift
@@ -6,7 +6,12 @@ public class Request {
     public init(url: URL, method: Method = .get, headers: Headers = [:]) {
         self.url = url
         self.method = method
-        self.headers = headers
+
+        if let userAgent = Global.userAgent {
+            self.headers = headers.merging(["User-Agent": userAgent]) { _, new in new }
+        } else {
+            self.headers = headers
+        }
     }
 
     // MARK: Internal

--- a/Tests/HTTPTests/BodyRequestTests.swift
+++ b/Tests/HTTPTests/BodyRequestTests.swift
@@ -52,6 +52,14 @@ class BodyRequestTests: XCTestCase {
         XCTAssertEqual(json["secondProperty"], "value")
     }
 
+    func test_init_setsGlobalUserAgent() throws {
+        Global.userAgent = "Custom User Agent"
+        let request = BodyRequest(url: URL.test, body: TestObject())
+
+        let urlRequest = request.asURLRequest
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "User-Agent"), "Custom User Agent")
+    }
+
     private func decodeRequest(_ request: Request) throws -> [String: String] {
         let urlRequest = request.asURLRequest
         let data = try XCTUnwrap(urlRequest.httpBody)

--- a/Tests/HTTPTests/RequestTests.swift
+++ b/Tests/HTTPTests/RequestTests.swift
@@ -28,4 +28,12 @@ class RequestTests: XCTestCase {
         let requestWithHeaders = Request(url: URL.test, headers: headers)
         XCTAssertEqual(requestWithHeaders.asURLRequest.allHTTPHeaderFields, headers)
     }
+
+    func test_init_setsGlobalUserAgent() throws {
+        Global.userAgent = "Custom User Agent"
+        let request = Request(url: URL.test)
+
+        let urlRequest = request.asURLRequest
+        XCTAssertEqual(urlRequest.value(forHTTPHeaderField: "User-Agent"), "Custom User Agent")
+    }
 }


### PR DESCRIPTION
Option to provide a global user agent used on all requests, setting the `"User-Agent"` HTTP header.

```swift
import HTTP

HTTP.Global.userAgent = "Custom User Agent"
```